### PR TITLE
Replace blank spaces with dashes in author_links for names with blank sp...

### DIFF
--- a/author_generator.rb
+++ b/author_generator.rb
@@ -118,7 +118,7 @@ module Jekyll
                authors = [ authors ]
       end
       authors = authors.map do |author|
-        "<a class='author' href='/#{dir}/#{author.downcase}/'>#{author}</a>"
+        "<a class='author' href='/#{dir}/#{author.downcase.gsub(' ', '-')}/'>#{author}</a>"
       end
       case authors.length
       when 0


### PR DESCRIPTION
It was just missing when generating the links for viewing the author's posts.
